### PR TITLE
Update deploy-mainnets.yml

### DIFF
--- a/.github/workflows/deploy-mainnets.yml
+++ b/.github/workflows/deploy-mainnets.yml
@@ -89,76 +89,21 @@ jobs:
           echo "Discovered matrix: ${MATRIX_JSON}"
           echo "matrix=${MATRIX_JSON}" >> "$GITHUB_OUTPUT"
 
-  deploy:
-    name: "Deploy to ${{ matrix.networkName }} (${{ matrix.chainId }})"
-    needs: discover-matrix
-    runs-on: ubuntu-latest
-    environment:
-      name: mainnet
-    timeout-minutes: 20
-    strategy:
-      fail-fast: false
-      max-parallel: 2
-      matrix: ${{ fromJSON(needs.discover-matrix.outputs.matrix) }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
-      - name: Determine pnpm store path
-        id: pnpm-store
-        shell: bash
-        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_ENV
-
-      - name: Cache pnpm store
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-node-20-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-20-pnpm-store-
-
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-20-node_modules-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-20-node_modules-
-
-      - name: Install dependencies
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: |
-          pnpm install --frozen-lockfile --ignore-scripts
-
-      - name: Run Catapult
-        env:
-          NETWORK_NAME: ${{ matrix.networkName }}
-          CHAIN_ID: ${{ matrix.chainId }}
-          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
-          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
-          RPC_BUILDER_KEY: ${{ secrets.RPC_BUILDER_KEY }}
-        run: |
-          set -euo pipefail
-          ./node_modules/.bin/catapult run -vvv -n "${CHAIN_ID}"
-
-      - name: Upload outputs artifact
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: catapult-outputs-${{ matrix.networkName }}-${{ matrix.chainId }}
-          path: outputs/**
-          if-no-files-found: ignore
+      deploy:
+      
+          name: "Deploy to ${{ matrix.networkName }} (${{ matrix.chainId }})"
+          needs: discover-matrix
+          concurrency:
+          group: deploy-mainnets-${{ github.workflow }}-${{ github.ref }}
+          cancel-in-progress: false
+          runs-on: ubuntu-latest
+          environment:
+            name: mainnet
+            timeout-minutes: 20
+          strategy:
+            fail-fast: false
+            max-parallel: 2
+            matrix: ${{ fromJSON(needs.discover-matrix.outputs.matrix) }}
 
 
   dry-run:


### PR DESCRIPTION
## Summary by Sourcery

Simplify the deploy job in the deploy-mainnets GitHub Actions workflow by removing granular action steps and introducing a concurrency configuration

Enhancements:
- Add concurrency grouping to the deploy job to prevent overlapping runs and coordinate parallelism

Chores:
- Remove detailed checkout, setup, caching, install, run, and artifact upload steps from the deploy job